### PR TITLE
feat(udp_socket): allow user to set internal socket buffer size

### DIFF
--- a/udp_driver/include/boost_udp_driver/udp_socket.hpp
+++ b/udp_driver/include/boost_udp_driver/udp_socket.hpp
@@ -17,12 +17,13 @@
 #ifndef UDP_DRIVER__UDP_SOCKET_HPP_
 #define UDP_DRIVER__UDP_SOCKET_HPP_
 
+#include "boost_io_context/io_context.hpp"
+
 #include <array>
+#include <cstddef>
+#include <cstdint>
 #include <string>
 #include <vector>
-
-#include "boost_io_context/io_context.hpp"
-#include "boost_msg_converters/converters.hpp"
 
 namespace drivers
 {
@@ -66,6 +67,16 @@ public:
   bool isOpen() const;
   void bind();
   void setMulticast(bool value);
+
+  /**
+   * @brief Set the socket's internal receive buffer size to `n_bytes`. See `SO_RCVBUF` in `man 7
+   * socket` for more information.
+   *
+   * @param n_bytes The number of bytes to allocate.
+   * @return true If the buffer has been resizes successfully.
+   * @return false If there was an error, such as the `net.core.rmem_max` value being exceeded.
+   */
+  bool setKernelBufferSize(int32_t n_bytes);
 
   /*
    * Blocking Send Operation

--- a/udp_driver/include/boost_udp_driver/udp_socket.hpp
+++ b/udp_driver/include/boost_udp_driver/udp_socket.hpp
@@ -19,7 +19,6 @@
 
 #include "boost_io_context/io_context.hpp"
 
-#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <string>

--- a/udp_driver/include/boost_udp_driver/udp_socket.hpp
+++ b/udp_driver/include/boost_udp_driver/udp_socket.hpp
@@ -73,7 +73,7 @@ public:
    * socket` for more information.
    *
    * @param n_bytes The number of bytes to allocate.
-   * @return true If the buffer has been resizes successfully.
+   * @return true If the buffer has been resized successfully.
    * @return false If there was an error, such as the `net.core.rmem_max` value being exceeded.
    */
   bool setKernelBufferSize(int32_t n_bytes);

--- a/udp_driver/src/udp_socket.cpp
+++ b/udp_driver/src/udp_socket.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "boost/asio.hpp"
+#include <boost/system/system_error.hpp>
 #include "rclcpp/logging.hpp"
 
 namespace drivers
@@ -261,6 +262,19 @@ void UdpSocket::bind()
 void UdpSocket::setMulticast(bool value)
 {
   m_use_multicast = value;
+}
+
+bool UdpSocket::setKernelBufferSize(int32_t n_bytes) {
+  boost::asio::socket_base::receive_buffer_size buffer_size_option{ n_bytes };
+
+  try {
+    m_udp_socket.set_option(buffer_size_option);
+  } catch (boost::system::system_error & error) {
+    RCLCPP_ERROR_STREAM(rclcpp::get_logger("UdpSocket::setkernelBufferSize"), error.what());
+    return false;
+  }
+
+  return true;
 }
 
 }  // namespace udp_driver

--- a/udp_driver/src/udp_socket.cpp
+++ b/udp_driver/src/udp_socket.cpp
@@ -16,15 +16,16 @@
 
 #include "boost_udp_driver/udp_socket.hpp"
 
+#include <rclcpp/logging.hpp>
+
+#include <boost/asio.hpp>
+#include <boost/system/system_error.hpp>
+
 #include <iostream>
-#include <utility>
 #include <string>
 #include <system_error>
+#include <utility>
 #include <vector>
-
-#include "boost/asio.hpp"
-#include <boost/system/system_error.hpp>
-#include "rclcpp/logging.hpp"
 
 namespace drivers
 {


### PR DESCRIPTION
## PR Type

- New Feature

## Related Links

- tier4/nebula#186 -- Nebula PR requiring this feature

## Description

This PR adds the ability to set the size of `SO_RECVBUF` in the underlying system's UDP socket used by `UdpSocket`.
Calling the new `setKernelBufferSize(n_bytes)` member function of a UdpSocket tries to set the corresponding option in Boost ASIO and returns a `bool` that indicates if the operation was successful.

*Code not actively invoking this feature is unaffected.*

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
