### PR TITLE
Reduce Log Spamming During TCP Socket Reconnection

### DIFF
--- a/tcp_driver/include/boost_tcp_driver/tcp_driver.hpp
+++ b/tcp_driver/include/boost_tcp_driver/tcp_driver.hpp
@@ -84,6 +84,15 @@ public:
   bool open();
 
   /**
+           * @brief Open the socket with set parameters
+           *
+           * @param repeat_hw_logging Set false to print logs just once
+           * @return true if the connect function was successful
+           * @return false if the connect function was not successful
+           */
+          bool open(bool repeat_hw_logging);
+
+  /**
            * @brief Close the socket (sync)
            *
            */

--- a/tcp_driver/include/boost_tcp_driver/tcp_socket.hpp
+++ b/tcp_driver/include/boost_tcp_driver/tcp_socket.hpp
@@ -117,6 +117,15 @@ public:
   bool open();
 
   /**
+           * @brief Open the socket with set parameters
+           *
+           * @param repeat_hw_logging Set false to print logs just once
+           * @return true if the connect function was successful
+           * @return false if the connect function was not successful
+           */
+  bool open(bool repeat_hw_logging);
+
+  /**
            * @brief Close the socket (sync)
            *
            */

--- a/tcp_driver/src/tcp_driver.cpp
+++ b/tcp_driver/src/tcp_driver.cpp
@@ -65,6 +65,11 @@ bool TcpDriver::open()
   return m_socket->open();
 }
 
+bool TcpDriver::open(bool repeat_hw_logging)
+{
+  return m_socket->open(repeat_hw_logging);
+}
+
 void TcpDriver::closeSync()
 {
   if(m_socket != NULL){

--- a/tcp_driver/src/tcp_socket.cpp
+++ b/tcp_driver/src/tcp_socket.cpp
@@ -505,13 +505,14 @@ bool TcpSocket::open()
   m_socket->open(boost::asio::ip::tcp::v4());
   m_socket->set_option(boost::asio::ip::tcp::socket::reuse_address(true));
 
-  std::cout << m_remote_endpoint << std::endl;
-
+  RCLCPP_INFO_ONCE(rclcpp::get_logger("TcpSocket::openning"), "Opening connection to: %s:%d", 
+  m_remote_endpoint.address().to_string().c_str(), 
+  m_remote_endpoint.port());
   boost::system::error_code ec = boost::asio::error::would_block;
   deadline_.expires_from_now(boost::posix_time::seconds(5));
   deadline_.async_wait([this](const boost::system::error_code& ec2) {
     if (!ec2) {
-      std::cerr << "# Canceling socket operation due to timeout (5s).\n";
+      RCLCPP_INFO_ONCE(rclcpp::get_logger("TcpSocket::openning"), "Canceling socket operation due to timeout (5s).");
       m_socket->cancel();
       m_ctx->restart();
     }
@@ -521,14 +522,14 @@ bool TcpSocket::open()
   do m_ctx->run_one(); while (ec == boost::asio::error::would_block);
 
   if (ec || !m_socket->is_open()) {
-    RCLCPP_ERROR_STREAM(rclcpp::get_logger("TcpSocket::open"), ec.message());
+    RCLCPP_ERROR_ONCE(rclcpp::get_logger("TcpSocket::open"), ec.message().c_str());
     m_socket->cancel();
     reset_flg = true;
     deadline_.cancel();
     m_ctx->restart();
     return false;
   } else {
-    RCLCPP_INFO_STREAM(rclcpp::get_logger("TcpSocket::open"), "connected");
+    RCLCPP_INFO_ONCE(rclcpp::get_logger("TcpSocket::open"), "connected");
   }
   reset_flg = false;
   deadline_.cancel();

--- a/tcp_driver/src/tcp_socket.cpp
+++ b/tcp_driver/src/tcp_socket.cpp
@@ -497,22 +497,31 @@ uint16_t TcpSocket::host_port() const
 {
   return m_host_endpoint.port();
 }
-
+bool TcpSocket::open(){
+  return this->open(true);
+}
 // https://stackoverflow.com/questions/32692195/set-timeout-for-boost-socket-connect
-bool TcpSocket::open()
+bool TcpSocket::open(bool repeat_hw_logging)
 {
   m_ctx->restart();
   m_socket->open(boost::asio::ip::tcp::v4());
   m_socket->set_option(boost::asio::ip::tcp::socket::reuse_address(true));
-
-  RCLCPP_INFO_ONCE(rclcpp::get_logger("TcpSocket::openning"), "Opening connection to: %s:%d", 
-  m_remote_endpoint.address().to_string().c_str(), 
-  m_remote_endpoint.port());
+  if(repeat_hw_logging){
+    std::cout << m_remote_endpoint << std::endl;
+  }else{
+    RCLCPP_INFO_ONCE(rclcpp::get_logger("TcpSocket::openning"), "Opening connection to: %s:%d", 
+    m_remote_endpoint.address().to_string().c_str(), 
+    m_remote_endpoint.port());
+  }
   boost::system::error_code ec = boost::asio::error::would_block;
   deadline_.expires_from_now(boost::posix_time::seconds(5));
-  deadline_.async_wait([this](const boost::system::error_code& ec2) {
+  deadline_.async_wait([this, repeat_hw_logging](const boost::system::error_code& ec2) {
     if (!ec2) {
-      RCLCPP_INFO_ONCE(rclcpp::get_logger("TcpSocket::openning"), "Canceling socket operation due to timeout (5s).");
+      if(repeat_hw_logging){
+        std::cerr << "# Canceling socket operation due to timeout (5s).\n";
+      }else{
+        RCLCPP_INFO_ONCE(rclcpp::get_logger("TcpSocket::openning"), "Canceling socket operation due to timeout (5s).");
+      }
       m_socket->cancel();
       m_ctx->restart();
     }
@@ -522,14 +531,22 @@ bool TcpSocket::open()
   do m_ctx->run_one(); while (ec == boost::asio::error::would_block);
 
   if (ec || !m_socket->is_open()) {
-    RCLCPP_ERROR_ONCE(rclcpp::get_logger("TcpSocket::open"), ec.message().c_str());
+    if(repeat_hw_logging){
+      std::cerr << "# Canceling socket operation due to timeout (5s).\n";
+    }else{
+      RCLCPP_ERROR_ONCE(rclcpp::get_logger("TcpSocket::open"), ec.message().c_str());
+    }
     m_socket->cancel();
     reset_flg = true;
     deadline_.cancel();
     m_ctx->restart();
     return false;
   } else {
-    RCLCPP_INFO_ONCE(rclcpp::get_logger("TcpSocket::open"), "connected");
+    if(repeat_hw_logging){
+      RCLCPP_INFO_STREAM(rclcpp::get_logger("TcpSocket::open"), "connected");
+    }else{
+      RCLCPP_INFO_ONCE(rclcpp::get_logger("TcpSocket::open"), "connected");
+    }
   }
   reset_flg = false;
   deadline_.cancel();


### PR DESCRIPTION
**Motivation:**
- In cases where reconnection is needed, the current implementation prints repeated log messages for each retry.
- This excessive logging clutters debugging output and makes it harder to identify critical issues.
- A cleaner approach is to allow logs to be printed only once during reconnection, while still enabling detailed logs if needed.

**Proposed Changes:**
- Introduced a new variable in the open() function to control log verbosity.
- Allows users to choose between repetitive logs or a single log entry.
- Ensures log behaviour does not change for current users.

**Impact:**
- Reduces unnecessary log output without affecting error reporting.
- Improves maintainability and debugging efficiency.
- Enhances configurability of the TCP socket driver.

**Testing:**
- Tested with different reconnection scenarios to verify that essential logs appear while redundant ones are suppressed.


This PR was assisted by @mbharatheesha.
Looking forward to feedback from the maintainers! Please let me know if any further refinements are required. Thanks!