### PR TITLE
fix(tcp): allow for socket re-open on connection failure

### DIFF
--- a/tcp_driver/src/tcp_driver.cpp
+++ b/tcp_driver/src/tcp_driver.cpp
@@ -67,14 +67,14 @@ bool TcpDriver::open()
 
 void TcpDriver::closeSync()
 {
-  if(m_socket != NULL){
+  if(isOpen()){
     m_socket->closeSync();
   }
 }
 
 void TcpDriver::close()
 {
-  if(m_socket != NULL){
+  if(isOpen()){
     m_socket->close();
   }
 }

--- a/tcp_driver/src/tcp_socket.cpp
+++ b/tcp_driver/src/tcp_socket.cpp
@@ -538,6 +538,10 @@ bool TcpSocket::open()
 
 void TcpSocket::closeSync()
 {
+  if (!isOpen()) {
+    return;
+  }
+
   boost::system::error_code error;
   m_socket->shutdown(boost::asio::ip::tcp::socket::shutdown_both, error);
   if (error && error != boost::system::errc::not_connected) {
@@ -551,6 +555,10 @@ void TcpSocket::closeSync()
 
 void TcpSocket::close()
 {
+  if (!isOpen()) {
+    return;
+  }
+
   m_ctx->post([this]() {
     boost::system::error_code error;
     m_socket->shutdown(boost::asio::ip::tcp::socket::shutdown_both, error);
@@ -564,7 +572,6 @@ void TcpSocket::close()
     if (error) {
       RCLCPP_ERROR_STREAM(rclcpp::get_logger("TcpSocket::close"), error.message());
     }
-    m_socket.reset();
   });
   m_ctx->run();
 }


### PR DESCRIPTION
When a socket is closed, its internal `m_socket` is set to `NULL`, but it is never reinstantiated, even on reopen, leading to a segfault.

This PR does not perform `close` operations if already closed, and does not set the socket to `NULL` on `close`. Technically, this leads to the socket handle remaining in an invalid state, but this will be cleared once the socket is `open`ed again.